### PR TITLE
fix publish failure on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,10 @@ jobs:
       - restore_cache:
           name: Restore build results cache
           key: build-output-v1-{{ .Branch }}-{{ .Revision }}
+      - restore_cache:
+          name: Restore dependency cache
+          keys:
+            - dependency-cache-v1-{{ checksum "yarn.lock" }}
       - run:
           name: Publish to npm
           command: npm run publish


### PR DESCRIPTION
The reason is that node_modules is not present, causing the
semantic-release command to fail.