### PR TITLE
ci: properly configure npm auth token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,9 @@ jobs:
           keys:
             - dependency-cache-v1-{{ checksum "yarn.lock" }}
       - run:
+          name: Prepare NPM auth token
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+      - run:
           name: Publish to npm
           command: npm run publish
 


### PR DESCRIPTION
Build https://circleci.com/gh/huy-nguyen/remark-github-plugin/17 failed
because it couldn't read the npm token. I attempt to fix by writing the
auth token to `~/.npmrc` per the instructions here
https://npme.npmjs.com/docs/workflow/travis.html.