### PR TITLE
ci: Update node version in CI docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:10
     steps:
       - checkout
       - restore_cache:
@@ -51,7 +51,7 @@ jobs:
 
   publish:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:10
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
This is done in the hope that the node 10 image will run yarn 1.7 to match the version on my machine. Otherwise, running `yarn` on my machine will cause the lock file to change.