### PR TITLE
fix: include lodash in build to avoid errors on end-users's machine

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,7 @@ const shouldMinify = !!process.env.minify;
 
 let plugins = [
   resolve({
-    extensions: ['.ts'],
+    extensions: ['.ts', '.js'],
   }),
   babel({
     exclude: 'node_modules/**',


### PR DESCRIPTION
By changing one more small setting in rollup's config, we ensure that
the lodash-es dependency is included in the build output. This helps
avoid problem when end-users use this package because their build
environment may not be able to handle ES module used in lodash-es.