### PR TITLE
build: re-enable codecov

### DIFF
--- a/.github/workflows/build_test_publish.yaml
+++ b/.github/workflows/build_test_publish.yaml
@@ -37,6 +37,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.UNIT_TEST_GITHUB_TOKEN }}
       - name: Run linters
         run: yarn run lint
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v1
       - name: Publish to npm
         uses: cycjimmy/semantic-release-action@v2
         with:


### PR DESCRIPTION
This was temporarily removed during the transition to GitHub actions.